### PR TITLE
move database username and password to non-version-controlled config …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Config Files for local development (Do Not Commit to Repo) ###
+application-default.properties

--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ Hello! This is Ashley!
 
 Hello this is Goldi
 
+When setting the project up to run locally, copy the file main/resources/application-default.properties.example and past it into the same folder.
+Change the name of the new file to application-default.properties.
+Change the values for my-username and my-password to the correct values.
+This file has been added to the .gitignore file and should not be committed to the repo to maintain security of username and password.
+

--- a/src/main/resources/application-default.properties.example
+++ b/src/main/resources/application-default.properties.example
@@ -1,0 +1,2 @@
+spring.datasource.username=my-username
+spring.datasource.password=my-password

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,4 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/violet_swap
-spring.datasource.username=test
-spring.datasource.password=test
 
 # Specify the DBMS
 spring.jpa.database = MYSQL


### PR DESCRIPTION
…file

Changed the username and password for local development. Added instructions in the README on how to add the necessary config file to get the username and password. I know it doesn't matter when doing local dev, but wanted to make this change as a good pattern for future test or prod versions.