### PR TITLE
Bug fix setting user in session

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client:3.1.2'
 	implementation 'org.springframework.security:spring-security-crypto:5.5.8'
 	implementation 'mysql:mysql-connector-java:8.0.33'

--- a/src/main/java/com/launchcode/violetSwap/controllers/EmailController.java
+++ b/src/main/java/com/launchcode/violetSwap/controllers/EmailController.java
@@ -1,0 +1,82 @@
+package com.launchcode.violetSwap.controllers;
+
+import com.launchcode.violetSwap.models.Email;
+import com.launchcode.violetSwap.models.User;
+import com.launchcode.violetSwap.models.data.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequestMapping("/contact")
+public class EmailController {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JavaMailSender javaMailSender;
+
+    @Value("${spring.mail.username}")
+    private String sender;
+
+
+    private Boolean sendEmail(Email email) {
+        try{
+            SimpleMailMessage mailMessage = new SimpleMailMessage();
+
+            mailMessage.setFrom(sender);
+            mailMessage.setTo(email.getRecipient());
+            mailMessage.setText(email.getBody());
+            mailMessage.setSubject(email.getSubject());
+
+            javaMailSender.send(mailMessage);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @PostMapping
+    public String processContactUserForm(@ModelAttribute Email email, String sendingUser, String receivingUser,
+                                         Errors errors, Model model, RedirectAttributes redirectAttributes) {
+
+        User sendingUserObj = userRepository.findByUsername(sendingUser);
+        User receivingUserObj = userRepository.findByUsername(receivingUser);
+
+        model.addAttribute("isCurrentUser", false);
+        model.addAttribute("currentUser", sendingUserObj);
+        model.addAttribute("displayedUser", receivingUserObj);
+
+        if (errors.hasErrors()) {
+            redirectAttributes.addFlashAttribute("message", "Could not send");
+            redirectAttributes.addFlashAttribute("alertClass", "alert-danger");
+            return "redirect:user/" + receivingUser;
+        }
+
+        email.setSubject("A message from " + sendingUser + ": " + email.getSubject());
+        email.setRecipient(receivingUserObj.getEmail());
+        Boolean emailSuccessful = sendEmail(email);
+
+
+        if (!emailSuccessful) {
+            redirectAttributes.addFlashAttribute("message", "Could not send");
+            redirectAttributes.addFlashAttribute("alertClass", "alert-danger");
+            return "redirect:user/" + receivingUser;
+        }
+
+        redirectAttributes.addFlashAttribute("message", "Message sent");
+        redirectAttributes.addFlashAttribute("alertClass", "alert-success");
+        return "redirect:user/" + receivingUser;
+
+    }
+
+}

--- a/src/main/java/com/launchcode/violetSwap/controllers/HomeController.java
+++ b/src/main/java/com/launchcode/violetSwap/controllers/HomeController.java
@@ -9,13 +9,7 @@ public class HomeController {
 
     @GetMapping("/")
     public String home() {
-        return "index";
+        return "redirect:/user/myDetails";
     }
 
-    @GetMapping("/secured")
-    public String secured() {
-
-        return "home";
-
-    }
 }

--- a/src/main/java/com/launchcode/violetSwap/controllers/UserController.java
+++ b/src/main/java/com/launchcode/violetSwap/controllers/UserController.java
@@ -142,4 +142,13 @@ public class UserController {
 
         return "user/details";
     }
+
+//    @PostMapping("/contact")
+//    public String sendMessageToUser(@RequestParam String email, String subject, String body,
+//                                    Errors errors, HttpServletRequest request, Model model) {
+//        if (errors.hasErrors()) {
+//            return "could not send message";
+//        }
+//
+//    }
 }

--- a/src/main/java/com/launchcode/violetSwap/controllers/UserController.java
+++ b/src/main/java/com/launchcode/violetSwap/controllers/UserController.java
@@ -42,45 +42,6 @@ public class UserController {
         return user.get();
     }
 
-    private static void setUserInSession(HttpSession session, User user) {
-        session.setAttribute(userSessionKey, user.getId());
-    }
-
-    @GetMapping
-    public String setUser(HttpServletRequest request) {
-
-        Principal principal = request.getUserPrincipal();
-        String authUsername;
-        LoginType loginType = null;
-
-        if (principal instanceof OAuth2AuthenticationToken) {
-            // github
-            authUsername = ((OAuth2AuthenticationToken) principal).getPrincipal().getAttribute("login");
-            loginType = LoginType.OAUTH_GITHUB;
-
-            if (authUsername == null) {
-                // gmail
-                String tokenEmail = ((OAuth2AuthenticationToken) principal).getPrincipal().getAttribute("email");
-                authUsername = tokenEmail.split("@")[0];
-                loginType = LoginType.OAUTH_GOOGLE;
-            }
-        } else {
-            authUsername = principal.getName();
-        }
-
-        User currentUser = userRepository.findByUsername(authUsername);
-
-        if (currentUser == null) {
-            User newUser = new User(authUsername, loginType);
-            userRepository.save(newUser);
-            currentUser = newUser;
-        }
-
-        setUserInSession(request.getSession(), currentUser);
-
-        return "redirect:/user/myDetails";
-    }
-
     @GetMapping("/myDetails")
     public String displayUserPage(HttpServletRequest request, Model model) {
 

--- a/src/main/java/com/launchcode/violetSwap/controllers/UserController.java
+++ b/src/main/java/com/launchcode/violetSwap/controllers/UserController.java
@@ -1,5 +1,6 @@
 package com.launchcode.violetSwap.controllers;
 
+import com.launchcode.violetSwap.models.Email;
 import com.launchcode.violetSwap.models.LoginType;
 import com.launchcode.violetSwap.models.User;
 import com.launchcode.violetSwap.models.data.UserRepository;
@@ -90,7 +91,7 @@ public class UserController {
         }
 
         model.addAttribute("isCurrentUser", true);
-        model.addAttribute("user", currentUser);
+        model.addAttribute("displayedUser", currentUser);
 
         return "user/details";
     }
@@ -138,17 +139,11 @@ public class UserController {
         }
 
         model.addAttribute("isCurrentUser", isCurrentUser);
-        model.addAttribute("user", userToDisplay);
+        model.addAttribute("currentUser", currentUser);
+        model.addAttribute("displayedUser", userToDisplay);
+        model.addAttribute("emailToSend", new Email());
 
         return "user/details";
     }
 
-//    @PostMapping("/contact")
-//    public String sendMessageToUser(@RequestParam String email, String subject, String body,
-//                                    Errors errors, HttpServletRequest request, Model model) {
-//        if (errors.hasErrors()) {
-//            return "could not send message";
-//        }
-//
-//    }
 }

--- a/src/main/java/com/launchcode/violetSwap/controllers/UserController.java
+++ b/src/main/java/com/launchcode/violetSwap/controllers/UserController.java
@@ -3,7 +3,6 @@ package com.launchcode.violetSwap.controllers;
 import com.launchcode.violetSwap.models.LoginType;
 import com.launchcode.violetSwap.models.User;
 import com.launchcode.violetSwap.models.data.UserRepository;
-import com.launchcode.violetSwap.models.dto.RegisterFormDTO;
 import com.launchcode.violetSwap.models.dto.UpdateFormDTO;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -90,6 +89,7 @@ public class UserController {
             return "redirect:/user/update";
         }
 
+        model.addAttribute("isCurrentUser", true);
         model.addAttribute("user", currentUser);
 
         return "user/details";
@@ -125,5 +125,21 @@ public class UserController {
         userRepository.save(currentUser);
 
         return "redirect:/user/myDetails";
+    }
+
+    @GetMapping("/{username}")
+    public String displayUserDetails(@PathVariable String username, HttpServletRequest request, Model model) {
+        User userToDisplay = userRepository.findByUsername(username);
+        User currentUser = getUserFromSession(request.getSession());
+        Boolean isCurrentUser = userToDisplay.equals(currentUser);
+
+        if (userToDisplay == null) {
+            return "user/details";
+        }
+
+        model.addAttribute("isCurrentUser", isCurrentUser);
+        model.addAttribute("user", userToDisplay);
+
+        return "user/details";
     }
 }

--- a/src/main/java/com/launchcode/violetSwap/models/Email.java
+++ b/src/main/java/com/launchcode/violetSwap/models/Email.java
@@ -1,0 +1,41 @@
+package com.launchcode.violetSwap.models;
+
+public class Email {
+
+    private String recipient;
+    private String subject;
+    private String body;
+
+    public Email() {}
+
+    public Email(String recipient, String subject, String body) {
+        super();
+        this.recipient = recipient;
+        this.subject = subject;
+        this.body = body;
+    }
+
+    public String getRecipient() {
+        return recipient;
+    }
+
+    public void setRecipient(String recipient) {
+        this.recipient = recipient;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+}

--- a/src/main/java/com/launchcode/violetSwap/security/AuthSuccessHandler.java
+++ b/src/main/java/com/launchcode/violetSwap/security/AuthSuccessHandler.java
@@ -1,0 +1,67 @@
+package com.launchcode.violetSwap.security;
+
+import com.launchcode.violetSwap.models.LoginType;
+import com.launchcode.violetSwap.models.User;
+import com.launchcode.violetSwap.models.data.UserRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class AuthSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+
+    @Autowired
+    private HttpSession session;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private static final String userSessionKey = "user";
+
+    private static void setUserInSession(HttpSession session, User user) {
+        session.setAttribute(userSessionKey, user.getId());
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+
+        String authUsername;
+        LoginType loginType = null;
+
+        if (authentication instanceof OAuth2AuthenticationToken) {
+            // github
+            authUsername = ((OAuth2AuthenticationToken) authentication).getPrincipal().getAttribute("login");
+            loginType = LoginType.OAUTH_GITHUB;
+
+            if (authUsername == null) {
+                // gmail
+                String tokenEmail = ((OAuth2AuthenticationToken) authentication).getPrincipal().getAttribute("email");
+                authUsername = tokenEmail.split("@")[0];
+                loginType = LoginType.OAUTH_GOOGLE;
+            }
+        } else {
+            authUsername = authentication.getName();
+        }
+
+        User currentUser = userRepository.findByUsername(authUsername);
+
+        if (currentUser == null) {
+            User newUser = new User(authUsername, loginType);
+            userRepository.save(newUser);
+            currentUser = newUser;
+        }
+
+        setUserInSession(request.getSession(), currentUser);
+
+        super.onAuthenticationSuccess(request, response, authentication);
+    }
+}

--- a/src/main/java/com/launchcode/violetSwap/security/SecurityConfig.java
+++ b/src/main/java/com/launchcode/violetSwap/security/SecurityConfig.java
@@ -1,6 +1,5 @@
-package com.launchcode.violetSwap.config;
+package com.launchcode.violetSwap.security;
 
-import com.launchcode.violetSwap.security.CustomAuthenticationProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +19,9 @@ public class SecurityConfig {
 
     @Autowired
     private CustomAuthenticationProvider customAuthProvider;
+
+    @Autowired
+    AuthSuccessHandler authenticationSuccessHandler;
 
     //Create an auth bean for spring security to use to create and track auth
     @Bean
@@ -48,14 +50,12 @@ public class SecurityConfig {
         //Allow users to authenticate via a login form, use the custom login page for this purpose and on successful auth route to "/secured"
         http.formLogin((form) -> form
                         .loginPage("/login")
-                        .defaultSuccessUrl("/user")
-                        .permitAll());
+                        .permitAll().successHandler(authenticationSuccessHandler));
 
         //Allow user to authenticate via oauth2, use the custom login page for this purpose
-        http.oauth2Login((oauth2 -> oauth2
+        http.oauth2Login(oauth2 -> oauth2
                         .loginPage("/login")
-                        .defaultSuccessUrl("/user")
-                        .permitAll()));
+                        .permitAll().successHandler(authenticationSuccessHandler));
 
         http.logout((logout) -> logout
                         .permitAll());

--- a/src/main/resources/templates/user/details.html
+++ b/src/main/resources/templates/user/details.html
@@ -8,22 +8,23 @@
 
 <h1>User Profile</h1>
 
-<th:block  th:if="${user != null}">
+<th:block  th:if="${displayedUser != null}">
     <div th:if="${isCurrentUser}">
         <h2>Hello Current User!</h2>
     </div>
     <div>
-        <h3 th:text="${user.username}"></h3>
-        <h4 th:text="${user.zipcode}"></h4>
+        <h3 th:text="${displayedUser.username}"></h3>
+        <h4 th:text="${displayedUser.zipcode}"></h4>
     </div>
-    <div>
-        <form th:action="@{/user/contact}" method="post">
-            <input type="hidden" th:name="recipient" th:value="${user.email}"/>
+    <div th:if="${!isCurrentUser}">
+        <form th:action="@{/contact}" method="post">
+            <input type="hidden" th:name="sendingUser" th:value="${currentUser.username}"/>
+            <input type="hidden" th:name="receivingUser" th:value="${displayedUser.username}"/>
             <label>Subject
-                <input th:field="emailSubject" class="form-control"/>
+                <input th:field="${emailToSend.subject}" class="form-control"/>
             </label>
             <label>Message
-                <textarea th:field="emailBody"></textarea>
+                <textarea th:field="${emailToSend.body}"></textarea>
             </label>
 
             <!-- Include CSRF token -->
@@ -31,10 +32,11 @@
 
             <input type="submit" value="Send Message" class="btn"/>
         </form>
+        <div th:if="${message}" th:text="${message}" th:class="${'alert ' + alertClass}"></div>
     </div>
 </th:block>
 
-<div th:unless="${user != null}">
+<div th:unless="${displayedUser != null}">
     <h2>This user does not exist!</h2>
 </div>
 

--- a/src/main/resources/templates/user/details.html
+++ b/src/main/resources/templates/user/details.html
@@ -17,6 +17,7 @@
         <h4 th:text="${displayedUser.zipcode}"></h4>
     </div>
     <div th:if="${!isCurrentUser}">
+        <h4 th:text="'Contact '+${displayedUser.username}"></h4>
         <form th:action="@{/contact}" method="post">
             <input type="hidden" th:name="sendingUser" th:value="${currentUser.username}"/>
             <input type="hidden" th:name="receivingUser" th:value="${displayedUser.username}"/>

--- a/src/main/resources/templates/user/details.html
+++ b/src/main/resources/templates/user/details.html
@@ -7,15 +7,39 @@
 <body>
 
 <h1>User Profile</h1>
-<div th:if="${isCurrentUser}">
-    <h2>Hello Current User!</h2>
-</div>
-<div  th:if="${user != null}">
-    <h3 th:text="${user.username}"></h3>
-    <h4 th:text="${user.zipcode}"></h4>
-</div>
+
+<th:block  th:if="${user != null}">
+    <div th:if="${isCurrentUser}">
+        <h2>Hello Current User!</h2>
+    </div>
+    <div>
+        <h3 th:text="${user.username}"></h3>
+        <h4 th:text="${user.zipcode}"></h4>
+    </div>
+    <div>
+        <form th:action="@{/user/contact}" method="post">
+            <input type="hidden" th:name="recipient" th:value="${user.email}"/>
+            <label>Subject
+                <input th:field="emailSubject" class="form-control"/>
+            </label>
+            <label>Message
+                <textarea th:field="emailBody"></textarea>
+            </label>
+
+            <!-- Include CSRF token -->
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+
+            <input type="submit" value="Send Message" class="btn"/>
+        </form>
+    </div>
+</th:block>
+
 <div th:unless="${user != null}">
     <h2>This user does not exist!</h2>
+</div>
+
+<div>
+    <form></form>
 </div>
 
 

--- a/src/main/resources/templates/user/details.html
+++ b/src/main/resources/templates/user/details.html
@@ -7,10 +7,16 @@
 <body>
 
 <h1>User Profile</h1>
-<div  th:if="${user != null}">
-<h3 th:text="${user.username}"></h3>
+<div th:if="${isCurrentUser}">
+    <h2>Hello Current User!</h2>
 </div>
-    <!-- <h4 th:text="${user.zipcode}"></h4>-->
+<div  th:if="${user != null}">
+    <h3 th:text="${user.username}"></h3>
+    <h4 th:text="${user.zipcode}"></h4>
+</div>
+<div th:unless="${user != null}">
+    <h2>This user does not exist!</h2>
+</div>
 
 
 </body>


### PR DESCRIPTION
The auth flow was initially set up to set the user in session after all of the login steps had been completed and user was routed to the default success page.

This meant that if a user did not explicitly go to the /login page, log in, and then try to navigate the site, the set in session steps were being skipped.

This code makes it so that the user is set in the session as a part of the auth flow before any redirection for success is done, so if the user successfully logs in at any point they will be set in the session.